### PR TITLE
Fix incorrect warning when dotnet dependency file missing

### DIFF
--- a/RoboClerk.DependenciesFile/DependenciesFilePlugin.cs
+++ b/RoboClerk.DependenciesFile/DependenciesFilePlugin.cs
@@ -76,7 +76,7 @@ namespace RoboClerk.DependenciesFile
         {
             if (!fileSystem.File.Exists(filename))
             {
-                logger.Warn($"Cannot find Gradle file \"{filename}\" no dependencies will be loaded from this file.");
+                logger.Warn($"Cannot find dotnet dependencies file \"{filename}\" no dependencies will be loaded from this file.");
                 return;
             }
             foreach (string line in fileSystem.File.ReadLines(filename))


### PR DESCRIPTION
## Summary
- fix plugin warning for missing dotnet dependencies file

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bcdaafb008324b0584d9ec2c5fd20